### PR TITLE
Feature/neverending needs

### DIFF
--- a/client/css/bulkgiving.css
+++ b/client/css/bulkgiving.css
@@ -480,19 +480,10 @@ body {
     bottom: 0;
 }
 
-.donation-row {
-    line-height: 1.5em;
-    text-align: left;
-}
-
 .need-row {
     background-color: #0099FF;
     line-height: 4em;
     text-align: left;
-}
-
-.need-progress {
-    margin-top: 1.4em;
 }
 
 .form {

--- a/client/scripts/organizationController.js
+++ b/client/scripts/organizationController.js
@@ -5,8 +5,7 @@ Template.organization.events({
 
       // Get value from form element
       var need = event.target.what.value;
-      var amount = event.target.amount.value;
-      Meteor.call("addNeed", need, amount, this.name, this._id);
+      Meteor.call("addNeed", need, this.name);
     }
 });
 
@@ -46,29 +45,56 @@ Template.organizationNeed.events({
 });
 
 Template.organizationNeed.helpers({
-  progress: function() {
-    var progress = (this.delivered / this.needed) * 100;
-    if (progress > 100) {
-      progress = 100
-    }
-    return progress;
-  },
-  promisedProgress: function() {
-    var progress = (this.planned / this.needed) * 100;
-    if (progress > 100) {
-      progress = 100
-    }
-    return progress;
-  },
   hasAccess: function() {
     var user = Meteor.user();
     return user && (user.organization == this.organization);
   },
-  donations: function() {
-    Meteor.subscribe('donations', this._id);
-    return Donations.find({ needId: this._id });
+
+  needProgressType: function() {
+    if(this.need == "HIGH") {
+      return "progress-bar-danger";
+    } else if (this.need == "MEDIUM") {
+      return "progress-bar-warning";
+    } else if (this.need == "LOW") {
+      return "progress-bar-success";
+    } else {
+      return "progress-bar-info";
+    }
   },
-  needLeft: function() {
-    return this.needed - this.delivered;
-  }
+
+  needProgressLength: function() {
+    if(this.need == "HIGH") {
+      return "20";
+    } else if (this.need == "MEDIUM") {
+      return "50";
+    } else if (this.need == "LOW") {
+      return "80";
+    } else {
+      return "50";
+    }
+  },
+
+  needUrgency: function() {
+    if(this.need == "HIGH") {
+      return "list-group-item-danger";
+    } else if (this.need == "MEDIUM") {
+      return "list-group-item-warning";
+    } else if (this.need == "LOW") {
+      return "list-group-item-success";
+    } else { 
+      return "list-group-item-info";
+    }
+  },
+
+  needUrgencyText: function() {
+    if(this.need == "HIGH") {
+      return "There is a large need for this item";
+    } else if (this.need == "MEDIUM") {
+      return "There is a need for this item";
+    } else if (this.need == "LOW") {
+      return "There is little need for this item";
+    } else {
+      return "";
+    }
+  },
 });

--- a/client/scripts/organizationController.js
+++ b/client/scripts/organizationController.js
@@ -27,20 +27,16 @@ Template.organization.helpers({
 });
 
 Template.organizationNeed.events({
-  "submit .new-donation": function (event) {
-    event.preventDefault();
-    var name = event.target.name.value;
-    var amount = parseInt(event.target.amount.value);
-    var expectedDelivery = event.target.expectedDelivery.value;
-    Meteor.call("addPlannedDonation", this._id, name, amount, expectedDelivery);
+  "click #low": function(event) {
+    Meteor.call("modifyNeed", this.title, "LOW", this.organization);
   },
-  "change .delivered": function(event) {
-    var delivered = event.target.checked;
-    if (delivered == true) {
-      Meteor.call("addDonation", this._id);
-    } else {
-      Meteor.call("removeDonation", this._id);
-    }
+
+  "click #medium": function(event) {
+    Meteor.call("modifyNeed", this.title, "MEDIUM", this.organization);
+  },
+
+  "click #high": function(event) {
+    Meteor.call("modifyNeed", this.title, "HIGH", this.organization);
   }
 });
 
@@ -48,30 +44,6 @@ Template.organizationNeed.helpers({
   hasAccess: function() {
     var user = Meteor.user();
     return user && (user.organization == this.organization);
-  },
-
-  needProgressType: function() {
-    if(this.need == "HIGH") {
-      return "progress-bar-danger";
-    } else if (this.need == "MEDIUM") {
-      return "progress-bar-warning";
-    } else if (this.need == "LOW") {
-      return "progress-bar-success";
-    } else {
-      return "progress-bar-info";
-    }
-  },
-
-  needProgressLength: function() {
-    if(this.need == "HIGH") {
-      return "20";
-    } else if (this.need == "MEDIUM") {
-      return "50";
-    } else if (this.need == "LOW") {
-      return "80";
-    } else {
-      return "50";
-    }
   },
 
   needUrgency: function() {

--- a/client/views/organization.html
+++ b/client/views/organization.html
@@ -23,7 +23,7 @@
   </section>
 </template>
 
-<template name="organizationInformation" >
+<template name="organizationInformation">
   {{#if hasAccessToOrganization}}
     <p><a id="organizationRedirect" href="{{pathFor route='organizations'}}/{{name}}/edit" class="btn btn-info">Edit my organization</a></p>
   {{/if}}
@@ -32,9 +32,20 @@
 
 <template name="organizationNeed">
   <div class="col-md-4 list-group-item {{needUrgency}}">
-    <div>{{title}} - {{needUrgencyText}}</div>
+    <div><h4>{{title}}</h4></div>
+    
+    {{#if hasAccess}}
+      <div class="dropdown">
+        <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+          Change Status
+          <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
+          <li><button type="button" class="btn btn-success btn-block btn-xs" id="low">Low</button></li>
+          <li><button type="button" class="btn btn-warning btn-block btn-xs" id="medium">Medium</button></li>
+          <li><button type="button" class="btn btn-danger  btn-block btn-xs" id="high">High</button></li>
+        </ul>
+      </div>
+    {{/if}}
   </div>
-  {{#if hasAccess}}
-  <!-- Changing needs goes here -->
-  {{/if}}
 </template>

--- a/client/views/organization.html
+++ b/client/views/organization.html
@@ -1,38 +1,24 @@
 <template name="organization">
   <section class="about">
-    <div class="container col-lg-offset-2">
-      <div class="row">
-        <div class="col-sm-8 text-center">
-          <h1>Welcome to {{name}}</h1>
-          {{> organizationInformation}}
-        </div>
+    <div class="container">
+      <div class="jumbotron">
+        <h1>Welcome to {{name}}</h1>
+        <p>{{> organizationInformation}}</p>
       </div>
-      <br>
-      <br>
-      <div class="col-sm-8">
+      <div class="col-md-12 list-group">
+      {{#each organizationNeeds name}}
+        {{> organizationNeed}}
+      {{/each}}
+      </div>
+      {{#if hasAccess}}
         <div class="row">
-          <div class="col-sm-3"><h4>Title</h4></div>
-          <div class="col-sm-2"><h4>Needed</h4></div>
-          <div class="col-sm-2"><h4>Planned</h4></div>
-          <div class="col-sm-5"><h4>Progress</h4></div>
+          <form class="new-need form">
+            <input class="col-sm-4" type="text" name="what" placeholder="What do you need?">
+            <div class="col-sm-1"></div>
+            <button type="submit" class="btn btn-success col-sm-2">Submit</button>
+          </form>
         </div>
-        {{#each organizationNeeds name}}
-          {{> organizationNeed}}
-        {{/each}}
-        <br>
-        <br>
-        {{#if hasAccess}}
-          <div class="row">
-            <form class="new-need form">
-              <input class="col-sm-4" type="text" name="what" placeholder="What do you need?">
-              <div class="col-sm-1"></div>
-              <input class="col-sm-4" type="text" name="amount" placeholder="How many?">
-              <div class="col-sm-1"></div>
-              <button type="submit" class="btn btn-success col-sm-2">Submit</button>
-            </form>
-          </div>
-        {{/if}}
-      </div>
+      {{/if}}
     </div>
   </section>
 </template>
@@ -45,59 +31,10 @@
 </template>
 
 <template name="organizationNeed">
-  <div class="row need-row">
-    <div class="col-sm-3">{{title}}</div>
-    <div class="col-sm-2">{{needLeft}}</div>
-    <div class="col-sm-2">{{planned}}</div>
-    <div class="col-sm-3">
-      <div class="progress need-progress">
-        <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{progress}}" aria-valuemin="0" aria-valuemax="100" style="width: {{progress}}%">
-        </div>
-        <div class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="{{promisedProgress}}" aria-valuemin="0" aria-valuemax="100" style="width: {{promisedProgress}}%">
-        </div>
-      </div>
-    </div>
-    <div class="col-sm-1">
-      <button data-toggle="collapse" data-target="#{{_id}}" type="submit" class="btn btn-success">Donate</button>
-    </div>
+  <div class="col-md-4 list-group-item {{needUrgency}}">
+    <div>{{title}} - {{needUrgencyText}}</div>
   </div>
   {{#if hasAccess}}
-    <br>
-    <div class="row donation-row">
-      <div class="col-sm-4"><h5>Name</h5></div>
-      <div class="col-sm-2"><h5>Amount</h5></div>
-      <div class="col-sm-4"><h5>Expected delivery</h5></div>
-      <div class="col-sm-2"><h5>Delivered?</h5></div>
-    </div>
-    {{#each donations}}
-        <hr>
-        {{> donation}}
-    {{/each}}
-    <hr>
+  <!-- Changing needs goes here -->
   {{/if}}
-  <div class="row donation-row collapse out" id={{_id}}>
-    <form class="new-donation form">
-      <input class="col-sm-3" type="text" name="name" placeholder="Your name">
-      <div class="col-sm-1"></div>
-      <input class="col-sm-1" type="number" name="amount" placeholder="Amount">
-      <div class="col-sm-1"></div>
-      <input class="col-sm-3" type="datetime" name="expectedDelivery" placeholder="When can you deliver?">
-      <div class="col-sm-1"></div>
-      <button type="submit" data-toggle="collapse" data-target="#{{_id}}" class="btn btn-success cols-sm-2">Save</button>
-    </form>
-  </div>
-  <br>
-</template>
-
-<template name="donation">
-  <div class="row donation-row">
-    <div class="col-sm-4">{{name}}</div>
-    <div class="col-sm-2">{{amount}}</div>
-    <div class="col-sm-4">{{expectedDelivery}}</div>
-    <div class="col-sm-2">
-      <form class="delivered">
-        <input type="checkbox" name="delivered" checked="{{delivered}}">
-      </form>
-    </div>
-  </div>
 </template>

--- a/server/needs.js
+++ b/server/needs.js
@@ -1,0 +1,19 @@
+// Need amount scale {HIGH (Red), MEDIUM (Yellow), LOW(Green)}
+// Why strings? Beucase we can introduce new values if we want.
+
+Meteor.methods({
+    addNeed: function(title, organizationName) {
+        var user = Meteor.users.findOne(this.userId);
+        if(user.organization == organizationName) {
+            var needId = Needs.insert({title: title, need: "HIGH", organization: organizationName, creator: this.userId });
+            return needId;
+        }
+    },
+
+    modifyNeed: function(title, amount, organizationName) {
+        var user = Meteor.users.findOne(this.userId);
+        if(user.organization == organizationName) {
+            var needId = Needs.update({title: title}, { $set: {need: amount}});
+        }
+    }
+});

--- a/server/organizations.js
+++ b/server/organizations.js
@@ -42,39 +42,6 @@ Meteor.methods({
                 }
             );
         }
-    },
-
-   addNeed: function(title, amount, organizationName, organizationId) {
-        var user = Meteor.users.findOne(this.userId);
-        if(user.organization == organizationName) {
-            var needId = Needs.insert({title: title, needed: amount, planned: 0, delivered: 0, organization: organizationName, creator: this.userId });
-            return needId;
-        }
-    },
-
-    addDonation: function(id) {
-        var user = Meteor.users.findOne(this.userId);
-        donation = Donations.findOne({_id: id});
-        need = Needs.findOne({_id: donation.needId});
-        if(user.organization == need.organization) {
-            Donations.update({_id: id}, {$set: {delivered: true}})
-            decreaseValue = (donation.amount * -1);
-            Needs.update({_id: donation.needId}, {$inc: {delivered: donation.amount, planned: decreaseValue}});
-        }
-    },
-    removeDonation: function(id) {
-        var user = Meteor.users.findOne(this.userId);
-        donation = Donations.findOne({_id: id});
-        need = Needs.findOne({_id: donation.needId});
-        if(user.organization == need.organization) {
-            Donations.update({_id: id}, {$set: {delivered: false}})
-            decreaseValue = (donation.amount * -1);
-            Needs.update({_id: donation.needId}, {$inc: {delivered: decreaseValue, planned: donation.amount}});
-        }
-    },
-    addPlannedDonation: function(needId, name, amount, expectedDelivery) {
-        Donations.insert({needId: needId, name: name, amount: amount, expectedDelivery: expectedDelivery});
-        Needs.update({_id: needId}, {$inc: {planned: amount}});
     }
 });
 


### PR DESCRIPTION
This is a suggestion that changes the behavior of needs. Rather than being finite things that can be completed needs are now always active and can only be toggled between three states, LOW, MEDIUM and HIGH. The reason for this change is to greatly reduce the maintenance work that an organization will have to do.

Needs are presented in a 3-column table where the cell color corresponds to the current state of the need.

I believe there is still a lot to be done with the needs, so this is just a PR to get things moving in this direction. For instance, off the top of my head, we could probably use
- Sorting - By name, by state, etc
- Hiding needs - Some needs go "out of season" (you don’t need winter clothes in spring)
- Deleting needs
- Grouping - the view gets cluttered quite quickly
- Better descriptions - Right now all there is is a name. That's probably not enough

Below is an image of how it looks when not logged in as admin
![bg-new-needs](https://cloud.githubusercontent.com/assets/2438475/12872545/3c983cac-cda6-11e5-8c85-8f9389664920.png)

And as an admin, changing the state of the first need
![bg-new-needs-admin](https://cloud.githubusercontent.com/assets/2438475/12872557/88220e8c-cda6-11e5-9f5f-33f70285d15e.png)

I would love to hear your comments! Especially @aquarius29, who originally started talking about these simpler needs :)

//Eng
