### PR TITLE
Removed option to log in with google for now

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -23,5 +23,4 @@ ejson
 spacebars
 check
 useraccounts:bootstrap
-accounts-google
 twbs:bootstrap

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,6 +1,4 @@
 accounts-base@1.2.2
-accounts-google@1.0.6
-accounts-oauth@1.1.8
 accounts-password@1.1.4
 accounts-ui@1.1.6
 accounts-ui-unstyled@1.1.8
@@ -31,7 +29,6 @@ ejson@1.0.7
 email@1.0.8
 fastclick@1.0.7
 geojson-utils@1.0.4
-google@1.1.7
 hot-code-push@1.0.0
 html-tools@1.0.5
 htmljs@1.0.5
@@ -62,8 +59,6 @@ mongo@1.1.3
 mongo-id@1.0.1
 npm-bcrypt@0.7.8_2
 npm-mongo@1.4.39_1
-oauth@1.1.6
-oauth2@1.1.5
 observe-sequence@1.0.7
 ordered-dict@1.0.4
 promise@0.5.1


### PR DESCRIPTION
I really do believe this is the way of the future, as I said in #11, but for the beta phase it is a bit confusing to have a sign in option that does not work. This is the reason why I disabled it for now. Ping @Solisol 
